### PR TITLE
Add a :hide_success option (defaulted to false) for those who only want a growl notification when compilation fails

### DIFF
--- a/lib/guard/coffeescript.rb
+++ b/lib/guard/coffeescript.rb
@@ -15,7 +15,8 @@ module Guard
 
       super(watchers, {
           :bare => false,
-          :shallow => false
+          :shallow => false,
+          :hide_success => false,
       }.merge(options))
     end
 

--- a/lib/guard/coffeescript/runner.rb
+++ b/lib/guard/coffeescript/runner.rb
@@ -8,7 +8,7 @@ module Guard
         def run(files, watchers, options = {})
           notify_start(files, options)
           changed_files, errors = compile_files(files, options, watchers)
-          notify_result(changed_files, errors)
+          notify_result(changed_files, errors, options)
 
           changed_files
         rescue ::CoffeeScript::EngineError => e
@@ -74,12 +74,12 @@ module Guard
           directories
         end
 
-        def notify_result(changed_files, errors)
-          if errors.empty?
+        def notify_result(changed_files, errors, options = {})
+          if !errors.empty?
+            ::Guard::Notifier.notify(errors.join("\n"), :title => 'CoffeeScript results', :image => :failed)
+          elsif !options[:hide_success]
             message = "Successfully generated #{ changed_files.join(', ') }"
             ::Guard::Notifier.notify(message, :title => 'CoffeeScript results')
-          else
-            ::Guard::Notifier.notify(errors.join("\n"), :title => 'CoffeeScript results', :image => :failed)
           end
         end
 

--- a/spec/guard/coffeescript/runner_spec.rb
+++ b/spec/guard/coffeescript/runner_spec.rb
@@ -60,6 +60,17 @@ describe Guard::CoffeeScript::Runner do
         Guard::Notifier.should_receive(:notify).with('Successfully generated javascripts/a.js', :title => 'CoffeeScript results')
         runner.run(['a.coffee'], [watcher], { :output => 'javascripts' })
       end
+
+      context 'with the :hide_success option set to true' do
+        let(:watcher) { Guard::Watcher.new('^app/coffeescripts/(.*)\.coffee') }
+
+        it 'compiles the CoffeeScripts to the output and creates nested directories' do
+          FileUtils.should_receive(:mkdir_p).with("#{ @project_path }/javascripts/x/y")
+          Guard::Notifier.should_not_receive(:notify).with('Successfully generated javascripts/a.js', :title => 'CoffeeScript results')
+          runner.run(['app/coffeescripts/x/y/a.coffee'], [watcher], { :output => 'javascripts', :hide_success => true })
+        end
+      end
     end
+
   end
 end

--- a/spec/guard/coffeescript_spec.rb
+++ b/spec/guard/coffeescript_spec.rb
@@ -18,10 +18,14 @@ describe Guard::CoffeeScript do
       it 'sets a default :shallow option' do
         guard.options[:shallow].should be_false
       end
+
+      it 'sets a default :hide_success option' do
+        guard.options[:hide_success].should be_false
+      end
     end
 
     context 'with other options than the default ones' do
-      let(:guard) { Guard::CoffeeScript.new(nil, { :output => 'output_folder', :bare => true, :shallow => true }) }
+      let(:guard) { Guard::CoffeeScript.new(nil, { :output => 'output_folder', :bare => true, :shallow => true, :hide_success => true }) }
 
       it 'sets the provided :bare option' do
         guard.options[:bare].should be_true
@@ -29,6 +33,10 @@ describe Guard::CoffeeScript do
 
       it 'sets the provided :shallow option' do
         guard.options[:shallow].should be_true
+      end
+
+      it 'sets the provided :hide_success option' do
+        guard.options[:hide_success].should be_true
       end
     end
 
@@ -74,7 +82,8 @@ describe Guard::CoffeeScript do
       Guard::CoffeeScript::Inspector.should_receive(:clean).with(['a.coffee', 'b.coffee']).and_return ['a.coffee']
       Guard::CoffeeScript::Runner.should_receive(:run).with(['a.coffee'], [], {
           :bare => false,
-          :shallow => false }).and_return ['a.js']
+          :shallow => false,
+          :hide_success => false }).and_return ['a.js']
       guard.run_on_change(['a.coffee', 'b.coffee'])
     end
 


### PR DESCRIPTION
I know a lot of folks hit "save" all the time instinctively, or use editors that save on every change automatically.  Hence a ton of Growls for successful compiles even when I'm just cleaning up whitespace gets old fast.  This branch adds a flag to hide success output.
