### PR TITLE
more flexible :bare option

### DIFF
--- a/lib/guard/coffeescript/runner.rb
+++ b/lib/guard/coffeescript/runner.rb
@@ -45,7 +45,17 @@ module Guard
         end
 
         def compile(file, options)
-          ::CoffeeScript.compile(File.read(file), options)
+          file_options = options_for_file(file, options)
+          ::CoffeeScript.compile(File.read(file), file_options)
+        end
+
+        def options_for_file(file, options)
+          return options unless options[:bare].respond_to? :include?
+          file_options = options.clone
+          filename = file[/([^\/]*)\.coffee/]
+          file_options[:bare] = file_options[:bare].include?(filename)
+
+          file_options
         end
 
         def process_compile_result(content, file, directory)

--- a/spec/guard/coffeescript/runner_spec.rb
+++ b/spec/guard/coffeescript/runner_spec.rb
@@ -33,6 +33,31 @@ describe Guard::CoffeeScript::Runner do
       end
     end
 
+    context 'with the :bare option set to an array of filenames' do
+      let(:watcher) { Guard::Watcher.new(%r{src/.+\.coffee}) }
+      
+      before do
+        runner.unstub(:compile)
+        ::CoffeeScript.stub(:compile)
+        File.stub(:read) {|file| file}
+      end
+
+      after do
+        runner.stub(:compile).and_return ''; ::CoffeeScript.unstub(:compile) 
+      end
+
+      it 'should compile files in the list without the outer function wrapper' do
+        ::CoffeeScript.should_receive(:compile).with 'src/a.coffee', hash_including(:bare => true) 
+        runner.run(['src/a.coffee', 'src/b.coffee'], [watcher], {:output => 'target', :bare => ['a.coffee']})
+      end
+
+      it 'should compile files not in the list with the outer function wrapper' do
+        ::CoffeeScript.should_receive(:compile).with 'src/b.coffee', hash_including(:bare => false) 
+        runner.run(['src/a.coffee', 'src/b.coffee'], [watcher], {:output => 'target', :bare => ['a.coffee']})
+      end
+
+    end
+
     context 'with the :shallow option set to false' do
       let(:watcher) { Guard::Watcher.new('^app/coffeescripts/(.*)\.coffee') }
 


### PR DESCRIPTION
If the user wants to compile some files in a directory with :bare => true but not others, they can pass an array of filenames (as strings) to :bare instead of true.  Each of these will be compiled with :bare => true. User does not have to list the whole or relative path, but does have to type the whole filename including extension
