### PR TITLE
support following at least one symlink

### DIFF
--- a/lib/guard/coffeescript.rb
+++ b/lib/guard/coffeescript.rb
@@ -58,7 +58,7 @@ module Guard
     # @raise [:task_has_failed] when stop has failed
     #
     def run_all
-      run_on_change(Watcher.match_files(self, Dir.glob(File.join('**', '*.coffee'))))
+      run_on_change(Watcher.match_files(self, Dir.glob('**{,/*/**}/*.coffee')))
     end
 
     # Gets called when watched paths and files have changes.

--- a/lib/guard/coffeescript/inspector.rb
+++ b/lib/guard/coffeescript/inspector.rb
@@ -16,9 +16,7 @@ module Guard
         def clean(paths)
           paths.uniq!
           paths.compact!
-          paths = paths.select { |p| coffee_file?(p) }
-          clear_coffee_files_list
-          paths
+          paths.select { |p| coffee_file?(p) }
         end
 
         private
@@ -29,23 +27,7 @@ module Guard
         # @return [Boolean] when the file valid
         #
         def coffee_file?(path)
-          coffee_files.include?(path)
-        end
-
-        # Scans the project and keeps a list of all
-        # CoffeeScript files.
-        #
-        # @see #clear_coffee_files_list
-        # @return [Array<String>] the valid files
-        #
-        def coffee_files
-          @coffee_files ||= Dir.glob('**/*.coffee')
-        end
-
-        # Clears the list of CoffeeScript files in this project.
-        #
-        def clear_coffee_files_list
-          @coffee_files = nil
+          path =~ /.coffee$/ && File.exists?(path)
         end
 
       end

--- a/spec/guard/coffeescript/inspector_spec.rb
+++ b/spec/guard/coffeescript/inspector_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Guard::CoffeeScript::Inspector do
   before do
-    Dir.stub(:glob).and_return 'a.coffee'
+    File.should_receive(:exists?).with("a.coffee").and_return true
   end
 
   let(:inspector) { Guard::CoffeeScript::Inspector }
@@ -17,12 +17,8 @@ describe Guard::CoffeeScript::Inspector do
     end
 
     it 'removes non-coffee files' do
-      inspector.clean(['a.coffee', 'b.txt']).should == ['a.coffee']
-    end
-
-    it 'frees up the list of coffee script files' do
-      inspector.should_receive(:clear_coffee_files_list)
-      inspector.clean(['a.coffee'])
+      File.should_receive(:exists?).with("doesntexist.coffee").and_return false
+      inspector.clean(['a.coffee', 'b.txt', 'doesntexist.coffee']).should == ['a.coffee']
     end
 
   end


### PR DESCRIPTION
`Dir.glob('**')` does not follow symlinks, whereas `Dir.glob('*')` might. As a result, this Guard plugin will not work with subpaths that follow a symlink.

As per http://stackoverflow.com/questions/357754/can-i-traverse-symlinked-directories-in-ruby-with-a-glob, you can follow at least one symlink with the provided pattern.

Additionally, there is little reason to walk the entire directory tree just to determine if some subset of files are actually coffeescript files. I suspect selectively testing file existence is both more performant and flexible.
