### PR TITLE
Fix file removal handling

### DIFF
--- a/lib/guard/coffeescript.rb
+++ b/lib/guard/coffeescript.rb
@@ -80,10 +80,7 @@ module Guard
     # @raise [:task_has_failed] when run_on_change has failed
     #
     def run_on_removals(paths)
-      Inspector.clean(paths).each do |file|
-        javascript = file.gsub(/(js\.coffee|coffee)$/, 'js')
-        File.remove(javascript) if File.exists?(javascript)
-      end
+      Runner.remove(Inspector.clean(paths, :missing_ok => true), watchers, options)
     end
 
     private

--- a/lib/guard/coffeescript/inspector.rb
+++ b/lib/guard/coffeescript/inspector.rb
@@ -11,12 +11,14 @@ module Guard
         # CoffeeScript files.
         #
         # @param [Array<String>] paths the changed paths
+        # @param [Hash] options
+        # @option options [String] :missing_ok don't remove missing files from list
         # @return [Array<String>] the valid spec files
         #
-        def clean(paths)
+        def clean(paths, options = {})
           paths.uniq!
           paths.compact!
-          paths.select { |p| coffee_file?(p) }
+          paths.select { |p| coffee_file?(p, options) }
         end
 
         private
@@ -26,8 +28,8 @@ module Guard
         # @param [String] file the file
         # @return [Boolean] when the file valid
         #
-        def coffee_file?(path)
-          path =~ /.coffee$/ && File.exists?(path)
+        def coffee_file?(path, options)
+          path =~ /.coffee$/ && (options[:missing_ok] || File.exists?(path))
         end
 
       end


### PR DESCRIPTION
This patch moves the file remove support to the runner so that it can share
the code to figure out where the corresponding output javascript file would
be and remove that.

It also adds a notifier so there's some feedback when something gets
automatically deleted.
