### PR TITLE
Fixed guard-coffeescript dying after a failed coffeescript compilation.

### DIFF
--- a/lib/guard/coffeescript/runner.rb
+++ b/lib/guard/coffeescript/runner.rb
@@ -95,7 +95,7 @@ module Guard
 
                 if options[:error_to_js]
                   js_error_message = "throw \"#{ error_message }\";"
-                  changed_files << write_javascript_file(js_error_message, file, directory, options)
+                  changed_files << write_javascript_file(js_error_message, nil, file, directory, options)
                 end
 
                 errors << error_message


### PR DESCRIPTION
I was receiving errors about a function call with the wrong number of arguments after coffeescript failed to compile due to syntax errors. This led to guard-coffeescript not working even after I fixed the syntax errors. I think this change fixes it.
