### PR TITLE
Add pre_process option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ There following options can be passed to Guard::CoffeeScript:
                                     # all sources
                                     # default: nil (using the `:input` directory)
 
+:pre_process => Proc.new {|f|...}   # Proc or lambda to pre process the script content before compilation.
+                                    # Accept one argument which is the file content.
+                                    # default: nil
+
 :hide_success => true               # Disable successful compilation messages.
                                     # default: false
 

--- a/lib/guard/coffeescript/runner.rb
+++ b/lib/guard/coffeescript/runner.rb
@@ -20,6 +20,7 @@ module Guard
         # @option options [Boolean] :hide_success hide success message notification
         # @option options [Boolean] :noop do not generate an output file
         # @option options [Boolean] :source_map generate the source map files
+        # @option options [Proc] :pre_process Proc or lambda to run with the file content before compilation
         # @return [Array<Array<String>, Boolean>] the result for the compilation run
         #
         def run(files, patterns, options = {})
@@ -111,10 +112,12 @@ module Guard
         # @param [String] filename the CoffeeScript file n
         # @param [Hash] options the options for the execution
         # @option options [Boolean] :source_map generate the source map files
+        # @option options [Proc] :pre_process Proc or lambda to run with the file content before compilation
         # @return [Array<String, String>] the JavaScript source and the source map
         #
         def compile(filename, options)
           file = File.read(filename)
+          file = options[:pre_process].call(file) if options[:pre_process].is_a? Proc
           file_options = options_for_file(filename, options)
 
           if options[:source_map]

--- a/spec/fixtures/script_with_pre_processing.coffee
+++ b/spec/fixtures/script_with_pre_processing.coffee
@@ -1,0 +1,1 @@
+alert 'raw coffee beans'

--- a/spec/guard/coffeescript/runner_integration_spec.rb
+++ b/spec/guard/coffeescript/runner_integration_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe Guard::CoffeeScript::Runner do
+  let(:runner) { Guard::CoffeeScript::Runner }
+  let(:pattern) { %r{spec/fixtures/.+\.coffee$} }
+  let(:formatter) { Guard::CoffeeScript::Formatter }
+
+  before do
+    allow(formatter).to receive(:notify)
+
+    Guard::CoffeeScript::Runner.last_run_failed = false
+  end
+  after do
+    FileUtils.rm_rf "#{@project_path}/tmp" if Dir.exist? "#{@project_path}/tmp"
+  end
+
+  describe 'run script with pre processing instruction' do
+    before { runner.run(["#{@project_path}/spec/fixtures/script_with_pre_processing.coffee"], [pattern], options) }
+    context 'no preprocessing option present' do
+      let(:options) { {output: 'tmp'} }
+      it do
+        file = File.read("#{@project_path}/tmp/script_with_pre_processing.js")
+        expect(file).to match(/alert\('raw coffee beans'\);/)
+      end
+    end
+    context 'with lambda preprocessing' do
+      let(:options) { {output: 'tmp', pre_process: ->(file) { file.gsub(/raw coffee beans/, 'grinded coffee') }} }
+      it do
+        file = File.read("#{@project_path}/tmp/script_with_pre_processing.js")
+        expect(file).to match(/alert\('grinded coffee'\);/)
+      end
+    end
+    context 'with proc preprocessing' do
+      let(:options) { {output: 'tmp', pre_process: Proc.new { |file| file.gsub(/raw coffee beans/, 'grinded coffee') }} }
+      it do
+        file = File.read("#{@project_path}/tmp/script_with_pre_processing.js")
+        expect(file).to match(/alert\('grinded coffee'\);/)
+      end
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'rake/ext/pathname'
+
+require 'guard/coffeescript/version'
 require 'guard/compat/test/helper'
 require 'guard/coffeescript'
 


### PR DESCRIPTION
Add pre_process option to allow a lambda to pre process the file content before compilation

Coffeescript
```
alert 'raw coffee beans'
```

Guard file
```
options = {
   pre_process: ->(file) { file.gsub(/raw coffee beans/, 'grinded coffee') },
   ...
}

guard :coffeescript, options
```

Output
```
(function() {
  alert('grinded coffee');
}).call(this);
```